### PR TITLE
Issue #71: Added strict filter mode for 'select' column types.

### DIFF
--- a/src/components/app/AppLayout/HeadContent.svelte
+++ b/src/components/app/AppLayout/HeadContent.svelte
@@ -47,11 +47,7 @@
     on:click={toggleMenu}
     override={{ d: 'block', '@sm': { d: 'none' } }}
   />
-  <a
-    class={styles.AppTitle}
-    href="/"
-    on:click={closeMenu}
-  >
+  <a class={styles.AppTitle} href="/" on:click={closeMenu}>
     <Group title={appTitle}>
       <RandoLogo size={35} />
       <Text color="blue" size="xl" override={{ d: 'none', '@sm': { d: 'block' } }}>

--- a/src/core/constants/rando/index.ts
+++ b/src/core/constants/rando/index.ts
@@ -2,3 +2,4 @@ export * from './pagination';
 export * from './propertiesDataSample';
 export * from './propertiesDataSpec';
 export * from './sectionTitles';
+export * from './useSelectFilterForColumns';

--- a/src/core/constants/rando/useSelectFilterForColumns.ts
+++ b/src/core/constants/rando/useSelectFilterForColumns.ts
@@ -1,0 +1,2 @@
+/** Use 'select' filter mode for data items with these id */
+export const useSelectFilterForColumns = ['unit', 'categories', 'role'];

--- a/src/core/helpers/data/filterHelpers.ts
+++ b/src/core/helpers/data/filterHelpers.ts
@@ -1,13 +1,27 @@
+import { TGenericEditableSpec } from '@/src/core/types/editable';
+import { useSelectFilterForColumns } from '@/src/core/constants/rando';
+
 type TFilterMatcherDefaultType = string | number;
 interface TFilterMatcherParams<T = TFilterMatcherDefaultType> {
   filterValue: T;
   value: T;
 }
 
-export const textContainsFilter = <T = TFilterMatcherDefaultType>({
-  filterValue,
-  value,
-}: TFilterMatcherParams<T>) => {
+export const textContainsFilter = <T = TFilterMatcherDefaultType>(
+  spec: TGenericEditableSpec,
+  { filterValue, value }: TFilterMatcherParams<T>,
+) => {
+  const { id } = spec;
+  const useStrictComparsion = useSelectFilterForColumns.includes(id);
+  /* console.log('[filterHelpers:textContainsFilter]', type, id, {
+   *   useStrictComparsion,
+   *   type,
+   *   id,
+   *   spec,
+   *   filterValue,
+   *   value,
+   * });
+   */
   if (value === '' || value == null) {
     return false;
   }
@@ -16,6 +30,9 @@ export const textContainsFilter = <T = TFilterMatcherDefaultType>({
   }
   if (Array.isArray(value)) {
     return value.includes(filterValue);
+  }
+  if (useStrictComparsion) {
+    return value === filterValue;
   }
   const cmpFilterValue = String(filterValue).toLowerCase();
   return String(value).toLowerCase().includes(cmpFilterValue);

--- a/src/core/helpers/data/multiLevelTable.ts
+++ b/src/core/helpers/data/multiLevelTable.ts
@@ -122,7 +122,7 @@ export function createMultiLevelTableColumns(
       if (filter) {
         colFilter = {
           // fn: textPrefixFilter,
-          fn: textContainsFilter,
+          fn: textContainsFilter.bind(null, item),
           render: (params) => {
             const {
               id, // "value"

--- a/src/core/helpers/rando/extendDataSetWithFilters.ts
+++ b/src/core/helpers/rando/extendDataSetWithFilters.ts
@@ -5,16 +5,14 @@ import {
   TGenericEditableSpec,
 } from '@/src/core/types/editable';
 import { ensureArray } from '@/src/core/helpers/basic';
+import { useSelectFilterForColumns } from '@/src/core/constants/rando';
 
 interface TExtendDataSetWithFiltersOptions {
   // TODO
 }
 
-// TODO: Move to constants...
-const selectFiltersFor = ['unit', 'categories', 'role'];
-
 function detectFilterTypeByLastId(id: string): TFilterItem {
-  return selectFiltersFor.includes(id) ? 'select' : true;
+  return useSelectFilterForColumns.includes(id) ? 'select' : true;
 }
 
 function getObjSpecFilters(

--- a/src/pages/DemoPage/DemoEditDataSet/DemoEditDataSet.svelte
+++ b/src/pages/DemoPage/DemoEditDataSet/DemoEditDataSet.svelte
@@ -36,6 +36,7 @@
     {
       source: {
         categories: ['X'],
+        unit: 'g',
       },
     },
   ];


### PR DESCRIPTION
Strict comparison mode applies for some data nodes depending on their ids (`useSelectFilterForColumns`: 'unit', 'categories', 'role').