### PR TITLE
Issue #8: Added 'date' data field types.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svelte-randonneur-app",
-  "version": "0.0.4",
+  "version": "0.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "svelte-randonneur-app",
-      "version": "0.0.4",
+      "version": "0.0.15",
       "hasInstallScript": true,
       "dependencies": {
         "@svelteuidev/composables": "^0.15.4",

--- a/src/components/data/EditableField/EditableField.svelte
+++ b/src/components/data/EditableField/EditableField.svelte
@@ -4,6 +4,7 @@
   import classNames from 'classnames';
 
   import { TEditableFieldSpec, TEditableFieldData } from '@/src/core/types/editable';
+  import { DateInput } from '@/src/components/forms/DateInput';
 
   import styles from './EditableField.module.scss';
 
@@ -25,11 +26,12 @@
 
   const { id, type } = spec;
 
-  $: console.log('[EditableField]', type, id, {
-    value,
-    type,
-    id,
-  });
+  /* $: console.log('[EditableField]', type, id, {
+   *   value,
+   *   type,
+   *   id,
+   * });
+   */
 
   const dispatch = createEventDispatcher();
 
@@ -38,16 +40,11 @@
   function handleChange(ev: CustomEvent<number> | Event) {
     const target = ev.target as HTMLInputElement;
     let value: TEditableFieldData;
-    console.log('[EditableField:handleChange]', {
-      target,
-      ev,
-    });
-    debugger;
     if (type === 'boolean') {
       value = !!target.checked;
-    } else if (type === 'string' || type === 'date') {
+    } else if (type === 'string') {
       value = target.value;
-    } else if (type === 'number') {
+    } else if (type === 'number' || type === 'date') {
       if ('detail' in ev) {
         value = ev.detail;
       }
@@ -76,13 +73,11 @@
   {:else if type === 'string'}
     <TextInput {value} label={spec.label} placeholder={spec.title} on:change={handleChange} />
   {:else if type === 'date'}
-    <!-- TODO: To use 'DateInput' -->
-    <TextInput
-      value="2018-07-00"
+    <DateInput
       label={spec.label}
       placeholder={spec.title}
+      value={String(value)}
       on:change={handleChange}
-      type="date"
     />
   {:else if type === 'number'}
     <NumberInput

--- a/src/components/data/EditableField/EditableField.svelte
+++ b/src/components/data/EditableField/EditableField.svelte
@@ -38,9 +38,14 @@
   function handleChange(ev: CustomEvent<number> | Event) {
     const target = ev.target as HTMLInputElement;
     let value: TEditableFieldData;
+    console.log('[EditableField:handleChange]', {
+      target,
+      ev,
+    });
+    debugger;
     if (type === 'boolean') {
       value = !!target.checked;
-    } else if (type === 'string') {
+    } else if (type === 'string' || type === 'date') {
       value = target.value;
     } else if (type === 'number') {
       if ('detail' in ev) {
@@ -73,7 +78,7 @@
   {:else if type === 'date'}
     <!-- TODO: To use 'DateInput' -->
     <TextInput
-      value="2018-07-22"
+      value="2018-07-00"
       label={spec.label}
       placeholder={spec.title}
       on:change={handleChange}

--- a/src/components/data/EditableField/EditableField.svelte
+++ b/src/components/data/EditableField/EditableField.svelte
@@ -76,7 +76,7 @@
     <DateInput
       label={spec.label}
       placeholder={spec.title}
-      value={String(value)}
+      value={value ? String(value) : ''}
       on:change={handleChange}
     />
   {:else if type === 'number'}

--- a/src/components/data/EditableField/EditableField.svelte
+++ b/src/components/data/EditableField/EditableField.svelte
@@ -25,6 +25,12 @@
 
   const { id, type } = spec;
 
+  $: console.log('[EditableField]', type, id, {
+    value,
+    type,
+    id,
+  });
+
   const dispatch = createEventDispatcher();
 
   // TODO: Store local value copy?
@@ -64,6 +70,15 @@
     <Switch class={styles.Switch} checked={!!value} label={spec.label} on:change={handleChange} />
   {:else if type === 'string'}
     <TextInput {value} label={spec.label} placeholder={spec.title} on:change={handleChange} />
+  {:else if type === 'date'}
+    <!-- TODO: To use 'DateInput' -->
+    <TextInput
+      value="2018-07-22"
+      label={spec.label}
+      placeholder={spec.title}
+      on:change={handleChange}
+      type="date"
+    />
   {:else if type === 'number'}
     <NumberInput
       value={value != null ? Number(value) : undefined}

--- a/src/components/data/EditableTable/EditableTableHelpers.ts
+++ b/src/components/data/EditableTable/EditableTableHelpers.ts
@@ -21,6 +21,24 @@ export function isScalarSpec(spec: TGenericEditableSpec): boolean {
   return isScalarType(type);
 }
 
+/** Regex used to test iso dates
+ * @see:
+ * - [Date and Time Formats](https://www.w3.org/TR/NOTE-datetime)
+ * - [4.7. Validate ISO 8601 Dates and Times - Regular Expressions Cookbook, 2nd Edition [Book]](https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s07.html)
+ * - [Regex to match an ISO 8601 datetime string - Stack Overflow](https://stackoverflow.com/questions/3143070/regex-to-match-an-iso-8601-datetime-string/3143231#3143231)
+ * TODO: Move to constants?
+ */
+const isoDateRegex =
+  /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/;
+
+/** Check for ISO date string, eg: 2023-12-22T01:23:45.67Z */
+export function isDateType(value: unknown): boolean {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  return isoDateRegex.test(value);
+}
+
 /** Create flat data object from real row data */
 export function makeFlatFromFullData(
   data: TEditableObjectData,

--- a/src/components/forms/DateInput/DateInput.module.scss
+++ b/src/components/forms/DateInput/DateInput.module.scss
@@ -1,0 +1,3 @@
+.DateInput {
+  /*!KEEP*/
+}

--- a/src/components/forms/DateInput/DateInput.svelte
+++ b/src/components/forms/DateInput/DateInput.svelte
@@ -20,8 +20,8 @@
   // TODO: Pass over all props from `TextInputProps`...
   // @see `node_modules/@svelteuidev/core/dist/components/TextInput/TextInput.svelte.d.ts`
 
-  $: textValue = value || new Date().toISOString();
-  $: dateValue = getValidOrCurrentDate(new Date(textValue));
+  $: textValue = value; // NOTE: Allows empty values!
+  $: dateValue = textValue ? getValidOrCurrentDate(new Date(textValue)) : new Date();
 
   let inputReference: HTMLInputElement;
   let popupReference: HTMLDivElement;
@@ -147,7 +147,7 @@
 <div class={classNames(className, styles.DateInput)}>
   <TextInput
     bind:element={inputReference}
-    value={textValue}
+    value={textValue || ''}
     on:change={handleTextDate}
     {label}
     {placeholder}

--- a/src/components/forms/DateInput/DateInput.svelte
+++ b/src/components/forms/DateInput/DateInput.svelte
@@ -99,6 +99,8 @@
      * });
      */
     if (isEscape) {
+      ev.preventDefault();
+      ev.stopPropagation();
       closeCalendarPopup();
     }
   }

--- a/src/components/forms/DateInput/DateInput.svelte
+++ b/src/components/forms/DateInput/DateInput.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import { DateInput, DatePicker } from 'date-picker-svelte';
+  import { ActionIcon, Box, Button, Center, Popper, TextInput } from '@svelteuidev/core';
+  import { Calendar } from 'radix-icons-svelte';
+  import classNames from 'classnames';
+
+  import { isValidDate } from '@/src/core/helpers/basic/dates';
+
+  import styles from './DateInput.module.scss';
+
+  export let className: string | undefined = undefined;
+
+  /** Expected text date representation in ISO format, eg: '2023-12-22T01:23:45.67Z' */
+  export let value: string | undefined = undefined;
+
+  $: textValue = value || new Date().toISOString();
+  $: dateValue = new Date(textValue);
+
+  $: console.log('XXX dateValue', dateValue);
+
+  let inputReference: HTMLInputElement;
+  let calendarOpened = false;
+
+  const dispatch = createEventDispatcher();
+
+  const toggleCalendarPopup = () => {
+    // TODO: On open set handlers for esc key press and outside click
+    calendarOpened = !calendarOpened;
+  };
+
+  function selectDate(ev: CustomEvent<Date>) {
+    const date = ev.detail;
+    dateValue = date;
+    textValue = date.toISOString();
+    console.log('[DateInput:selectDate]', {
+      dateValue,
+      textValue,
+      date,
+      ev,
+    });
+  }
+
+  function handleTextDate(ev: CustomEvent<string>) {
+    const input = ev.currentTarget as HTMLInputElement;
+    const text = input?.value;
+    // const text = ev.detail;
+    textValue = text;
+    const newDate = new Date(text);
+    if (isValidDate(newDate)) {
+      dateValue = newDate;
+    }
+    console.log('[DateInput:handleTextDate]', {
+      dateValue,
+      textValue,
+      text,
+      ev,
+    });
+    dispatch('change', ev);
+  }
+</script>
+
+<div class={classNames(className, styles.DateInput)}>
+  <TextInput
+    bind:element={inputReference}
+    value={dateValue.toISOString()}
+    on:change={handleTextDate}
+  >
+    <svelte:fragment slot="rightSection">
+      <ActionIcon on:click={toggleCalendarPopup} title="Toggle date selector">
+        <Calendar />
+      </ActionIcon>
+    </svelte:fragment>
+  </TextInput>
+  <Popper
+    title="Select date"
+    mounted={calendarOpened}
+    reference={inputReference}
+    position="bottom"
+    placement="start"
+    gutter={4}
+  >
+    <DatePicker value={dateValue} timePrecision="second" on:select={selectDate} />
+  </Popper>
+</div>

--- a/src/components/forms/DateInput/DateInput.svelte
+++ b/src/components/forms/DateInput/DateInput.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
-  import { DateInput, DatePicker } from 'date-picker-svelte';
-  import { ActionIcon, Box, Button, Center, Popper, TextInput } from '@svelteuidev/core';
+  import { DatePicker } from 'date-picker-svelte';
+  import { ActionIcon, Popper, TextInput } from '@svelteuidev/core';
   import { Calendar } from 'radix-icons-svelte';
   import classNames from 'classnames';
 
@@ -14,57 +14,141 @@
   /** Expected text date representation in ISO format, eg: '2023-12-22T01:23:45.67Z' */
   export let value: string | undefined = undefined;
 
-  $: textValue = value || new Date().toISOString();
-  $: dateValue = new Date(textValue);
+  export let label: string | undefined = undefined;
+  export let placeholder: string | undefined = undefined;
 
-  $: console.log('XXX dateValue', dateValue);
+  // TODO: Pass over all props from `TextInputProps`...
+  // @see `node_modules/@svelteuidev/core/dist/components/TextInput/TextInput.svelte.d.ts`
+
+  $: textValue = value || new Date().toISOString();
+  $: dateValue = getValidOrCurrentDate(new Date(textValue));
 
   let inputReference: HTMLInputElement;
+  let popupReference: HTMLDivElement;
   let calendarOpened = false;
+
+  $: handleOpenedStatus(calendarOpened);
 
   const dispatch = createEventDispatcher();
 
-  const toggleCalendarPopup = () => {
+  function getValidOrCurrentDate(date: Date): Date {
+    return isValidDate(date) ? date : new Date();
+  }
+
+  function toggleCalendarPopup() {
     // TODO: On open set handlers for esc key press and outside click
     calendarOpened = !calendarOpened;
-  };
+  }
+
+  function closeCalendarPopup() {
+    calendarOpened = false;
+  }
+
+  function dispatchChangeEvent() {
+    dispatch('change', textValue);
+  }
 
   function selectDate(ev: CustomEvent<Date>) {
     const date = ev.detail;
     dateValue = date;
-    textValue = date.toISOString();
-    console.log('[DateInput:selectDate]', {
-      dateValue,
-      textValue,
-      date,
-      ev,
-    });
+    const text = date.toISOString();
+    if (text !== textValue) {
+      textValue = text;
+      /* console.log('[DateInput:selectDate]', {
+       *   dateValue,
+       *   textValue,
+       *   date,
+       *   ev,
+       * });
+       */
+      dispatchChangeEvent();
+    }
   }
 
   function handleTextDate(ev: CustomEvent<string>) {
     const input = ev.currentTarget as HTMLInputElement;
     const text = input?.value;
-    // const text = ev.detail;
-    textValue = text;
-    const newDate = new Date(text);
-    if (isValidDate(newDate)) {
-      dateValue = newDate;
+    if (text !== textValue) {
+      // const text = ev.detail;
+      textValue = text;
+      const newDate = new Date(text);
+      if (isValidDate(newDate)) {
+        dateValue = newDate;
+      } else {
+        // NOTE: To set date to current value otherwise?
+        dateValue = new Date();
+      }
+      /* console.log('[DateInput:handleTextDate]', {
+       *   dateValue,
+       *   textValue,
+       *   text,
+       *   ev,
+       * });
+       */
+      dispatchChangeEvent();
     }
-    console.log('[DateInput:handleTextDate]', {
-      dateValue,
-      textValue,
-      text,
-      ev,
-    });
-    dispatch('change', ev);
+  }
+
+  function checkEscPress(ev: KeyboardEvent) {
+    const { key } = ev;
+    const isEscape = key === 'Escape';
+    /* console.log('[DateInput:checkEscPress]', {
+     *   isEscape,
+     *   key,
+     *   ev,
+     * });
+     */
+    if (isEscape) {
+      closeCalendarPopup();
+    }
+  }
+
+  function checkOuterClick(ev: MouseEvent) {
+    if (!popupReference) {
+      return;
+    }
+    const rect = popupReference.getBoundingClientRect();
+    const { left, right, top, bottom } = rect;
+    const { clientX, clientY } = ev;
+    const isInside = clientX >= left && clientX <= right && clientY >= top && clientY <= bottom;
+    /* console.log('[DateInput:checkOuterClick]', {
+     *   isInside,
+     *   rect,
+     *   left,
+     *   right,
+     *   top,
+     *   bottom,
+     *   clientX,
+     *   clientY,
+     *   ev,
+     *   popupReference,
+     * });
+     */
+    if (!isInside) {
+      closeCalendarPopup();
+    }
+  }
+
+  function handleOpenedStatus(isOpen: boolean) {
+    if (typeof document !== 'undefined' && typeof window !== 'undefined') {
+      if (isOpen) {
+        document.addEventListener('keydown', checkEscPress);
+        document.addEventListener('mousedown', checkOuterClick);
+      } else {
+        document.removeEventListener('keydown', checkEscPress);
+        document.removeEventListener('mousedown', checkOuterClick);
+      }
+    }
   }
 </script>
 
 <div class={classNames(className, styles.DateInput)}>
   <TextInput
     bind:element={inputReference}
-    value={dateValue.toISOString()}
+    value={textValue}
     on:change={handleTextDate}
+    {label}
+    {placeholder}
   >
     <svelte:fragment slot="rightSection">
       <ActionIcon on:click={toggleCalendarPopup} title="Toggle date selector">
@@ -73,6 +157,7 @@
     </svelte:fragment>
   </TextInput>
   <Popper
+    bind:element={popupReference}
     title="Select date"
     mounted={calendarOpened}
     reference={inputReference}

--- a/src/components/forms/DateInput/index.ts
+++ b/src/components/forms/DateInput/index.ts
@@ -1,0 +1,2 @@
+export * from './DateInput.svelte';
+export { default as DateInput } from './DateInput.svelte';

--- a/src/core/helpers/basic/dates.ts
+++ b/src/core/helpers/basic/dates.ts
@@ -1,0 +1,16 @@
+export function isValidDate(d: Date): boolean {
+  if (Object.prototype.toString.call(d) === '[object Date]') {
+    // it is a date
+    if (!d.getTime()) {
+      // d.getTime() or d.valueOf() will also work
+      // date object is not valid
+      return false;
+    } else {
+      // date object is valid
+      return true;
+    }
+  } else {
+    // not a date object
+    return false;
+  }
+}

--- a/src/core/helpers/basic/index.ts
+++ b/src/core/helpers/basic/index.ts
@@ -1,4 +1,5 @@
 export * from './arrays';
+export * from './dates';
 export * from './errors';
 export * from './numbers';
 export * from './strings';

--- a/src/core/helpers/rando/deriveDataSetSpec.test.ts
+++ b/src/core/helpers/rando/deriveDataSetSpec.test.ts
@@ -45,6 +45,23 @@ describe('deriveDataSetSpec', () => {
       const result: TGenericEditableSpec = deriveDataSetSpec('testObj', data);
       expect(result).toStrictEqual(expectedResult);
     });
+    it('date', () => {
+      const data: TDataSetDictSlot = {
+        testDate: '2023-12-22T01:23:45.67Z',
+      };
+      const expectedResult: TGenericEditableSpec = {
+        id: 'testObj',
+        spec: [
+          {
+            id: 'testDate',
+            type: 'date',
+          },
+        ],
+        type: 'object',
+      };
+      const result: TGenericEditableSpec = deriveDataSetSpec('testObj', data);
+      expect(result).toStrictEqual(expectedResult);
+    });
   });
   describe('should derive complex types', () => {
     it('properties object', () => {
@@ -188,6 +205,31 @@ describe('deriveDataSetSpec', () => {
                 },
               ],
             },
+          },
+        ],
+      };
+      const result: TGenericEditableSpec = deriveDataSetSpec('sample', data);
+      expect(result).toStrictEqual(expectedResult);
+    });
+    it('dataset with a list of dates', () => {
+      const data: TDataSetDictSlot = {
+        root: [
+          {
+            date: '2023-12-22T01:23:45.67Z',
+          },
+          {
+            date: '2020-01-01T00:00:00.00Z',
+          },
+        ],
+      } as unknown as TDataSetDictSlot;
+      const expectedResult: TGenericEditableSpec = {
+        id: 'sample',
+        type: 'object',
+        spec: [
+          {
+            id: 'root',
+            type: 'list',
+            spec: { id: 'root-item', type: 'object', spec: [{ id: 'date', type: 'date' }] },
           },
         ],
       };

--- a/src/core/helpers/rando/deriveDataSetSpec.test.ts
+++ b/src/core/helpers/rando/deriveDataSetSpec.test.ts
@@ -236,5 +236,33 @@ describe('deriveDataSetSpec', () => {
       const result: TGenericEditableSpec = deriveDataSetSpec('sample', data);
       expect(result).toStrictEqual(expectedResult);
     });
+    it('dataset with a list of optional dates', () => {
+      const data: TDataSetDictSlot = {
+        root: [
+          {
+            date: undefined,
+          },
+          {
+            date: '2020-01-01T00:00:00.00Z',
+          },
+          {
+            date: undefined,
+          },
+        ],
+      } as unknown as TDataSetDictSlot;
+      const expectedResult: TGenericEditableSpec = {
+        id: 'sample',
+        type: 'object',
+        spec: [
+          {
+            id: 'root',
+            type: 'list',
+            spec: { id: 'root-item', type: 'object', spec: [{ id: 'date', type: 'date' }] },
+          },
+        ],
+      };
+      const result: TGenericEditableSpec = deriveDataSetSpec('sample', data);
+      expect(result).toStrictEqual(expectedResult);
+    });
   });
 });

--- a/src/core/helpers/rando/deriveDataSetSpec.ts
+++ b/src/core/helpers/rando/deriveDataSetSpec.ts
@@ -8,7 +8,7 @@ import {
   // TScalarValue,
   TScalarValueType,
 } from '@/src/core/types/editable';
-import { isScalarType } from '@/src/components/data/EditableTable/EditableTableHelpers';
+import { isDateType, isScalarType } from '@/src/components/data/EditableTable/EditableTableHelpers';
 
 export interface TDeriveOpts {
   // maxDictListSize?: number;
@@ -59,6 +59,8 @@ function getNewValWithOldVal(
     if (typeof oldVal !== 'string') {
       return newVal;
     }
+    // WTF?
+    return oldVal;
   } else {
     return undefined;
   }
@@ -141,7 +143,10 @@ export function deriveListItemSpec(
 
 function createScalarSpec(id: string, value: TDataSetDictItemValue) {
   const dataType = typeof value;
-  const type = isScalarType(dataType) ? (dataType as TScalarValueType) : 'string';
+  let type = isScalarType(dataType) ? (dataType as TScalarValueType) : 'string';
+  if (type === 'string' && isDateType(value)) {
+    type = 'date';
+  }
   const scalarSpec: TEditableFieldSpec = {
     id,
     type,

--- a/src/core/helpers/rando/deriveDataSetSpec.ts
+++ b/src/core/helpers/rando/deriveDataSetSpec.ts
@@ -46,7 +46,7 @@ function getNewValWithOldVal(
   oldVal: TDataSetDictItemValue,
 ): TDataSetDictItemValue {
   if (newVal == null || oldVal == null) {
-    return newVal;
+    return newVal || oldVal;
   } else if (typeof newVal === 'object') {
     if (typeof oldVal !== 'object') {
       return newVal;

--- a/src/core/types/editable/TEditableValue.ts
+++ b/src/core/types/editable/TEditableValue.ts
@@ -5,6 +5,7 @@ export const scalarValueTypes = [
   'number',
   'boolean',
   'select',
+  'date',
 ] as const;
 export type TScalarValueType = (typeof scalarValueTypes)[number];
 export type TScalarValuesListType = TScalarValueType[];

--- a/src/pages/DemoPage/DemoDates/DemoDates.svelte
+++ b/src/pages/DemoPage/DemoDates/DemoDates.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { DateInput, DatePicker } from 'date-picker-svelte';
+  import { DatePicker } from 'date-picker-svelte';
   import { Month } from '@svelteuidev/dates';
   import { ActionIcon, Box, Button, Center, Popper, TextInput } from '@svelteuidev/core';
   import { Calendar } from 'radix-icons-svelte';
@@ -12,6 +12,7 @@
 
   import { EditableField } from '@/src/components/data';
   import { isValidDate } from '@/src/core/helpers/basic/dates';
+  import { DateInput } from '@/src/components/forms/DateInput';
   // import { TEditableFieldSpec } from '@/src/core/types/editable';
 
   // let buttonReference: HTMLAnchorElement | HTMLButtonElement;
@@ -26,11 +27,11 @@
   const createdDateStrZ = '2023-12-22T01:23:45.67Z';
 
   let textValue = createdDateStrZ;
-  let value = new Date(textValue);
+  let dateValue = new Date(textValue);
 
   /*
    * const dateFormat = 'YYYY-MM-DD HH:mm:ss'; // TODO: To use iso format (above)
-   * const dayjsDate = dayjs(value);
+   * const dayjsDate = dayjs(dateValue);
    * const fmtDate = dayjsDate.format(dateFormat);
    * // eslint-disable-next-line no-console
    * console.log('[DemoDates] Test', {
@@ -41,10 +42,10 @@
 
   function selectDate(ev: CustomEvent<Date>) {
     const date = ev.detail;
-    value = date;
+    dateValue = date;
     textValue = date.toISOString();
     console.log('selectDate', {
-      value,
+      dateValue,
       textValue,
       date,
       ev,
@@ -58,16 +59,22 @@
     textValue = text;
     const newDate = new Date(text);
     if (isValidDate(newDate)) {
-      value = newDate;
+      dateValue = newDate;
     }
     console.log('selectDate', {
-      value,
+      dateValue,
       textValue,
       text,
       ev,
     });
     debugger;
   }
+
+  // function dateInputChange(ev: unknown) {
+  //   console.log('[DemoDates:dateInputChange]', {
+  //     ev,
+  //   });
+  // }
 </script>
 
 <div class="DemoDates">
@@ -77,22 +84,24 @@
     <EditableField spec={{ id: 'testString', type: 'string' }} />
 
     <h2>DateInput:</h2>
-    <DateInput bind:value />
+    <DateInput bind:dateValue />
     -->
 
     <h2>DatePicker:</h2>
-    <DatePicker {value} timePrecision="second" on:select={selectDate} />
+    <DatePicker value={dateValue} timePrecision="second" on:select={selectDate} />
 
     <!--
     <h2>Month:</h2>
-    <Month bind:value month={value} onChange={(val) => (value = val)} />
+    <Month bind:dateValue month={dateValue} onChange={(val) => (dateValue = val)} />
     -->
 
+    <!-- // NOTE: Already implemented in `DateInput`...
     <h2>Button & Popper:</h2>
-    <!--
-    <Button bind:element={buttonReference} on:click={toggleCalendarPopup}>{value.toISOString()}</Button>
-    -->
-    <TextInput bind:element={inputReference} value={value.toISOString()} on:change={handleTextDate}>
+    <TextInput
+      bind:element={inputReference}
+      value={dateValue.toISOString()}
+      on:change={handleTextDate}
+    >
       <svelte:fragment slot="rightSection">
         <ActionIcon on:click={toggleCalendarPopup} title="Toggle date selector">
           <Calendar />
@@ -107,33 +116,15 @@
       placement="start"
       gutter={4}
     >
-      <DatePicker {value} timePrecision="second" on:select={selectDate} />
+      <DatePicker value={dateValue} timePrecision="second" on:select={selectDate} />
     </Popper>
 
-    <!--
       TODO: To create `DateInput` input type. Use in `EditableField`.
     -->
 
-    <EditableField spec={{ id: 'testDate', type: 'date' }} value={value.toISOString()} />
+    <DateInput value={textValue} on:change={handleTextDate} />
 
-    <!--
-    // prettier-ignore
-    <EditableField
-      spec={{ id: 'testBoolean', type: 'boolean', title: 'Test boolean' }}
-      value={false}
-    />
-    <EditableField spec={{ id: 'testString', type: 'string' }} />
-    <EditableField spec={{ id: 'testNumber', type: 'number', title: 'Test number' }} value={1} />
-    <EditableField
-      spec={{
-        id: 'testSelect',
-        type: 'select',
-        title: 'Test select',
-        selectData: [{ label: 'A', value: 'a' }, { label: 'B', value: 'b' }, 'C', 'D'],
-      }}
-      value={'C'}
-    />
-    -->
+    <EditableField spec={{ id: 'testDate', type: 'date' }} value={textValue} />
   </div>
 </div>
 

--- a/src/pages/DemoPage/DemoDates/DemoDates.svelte
+++ b/src/pages/DemoPage/DemoDates/DemoDates.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { DateInput, DatePicker } from 'date-picker-svelte';
   import { Month } from '@svelteuidev/dates';
-  import { Box, Button, Center, Popper } from '@svelteuidev/core';
+  import { ActionIcon, Box, Button, Center, Popper, TextInput } from '@svelteuidev/core';
+  import { Calendar } from 'radix-icons-svelte';
   import dayjs from 'dayjs';
 
   // @see:
@@ -10,34 +11,62 @@
   // - https://www.npmjs.com/package/date-picker-svelte
 
   import { EditableField } from '@/src/components/data';
+  import { isValidDate } from '@/src/core/helpers/basic/dates';
   // import { TEditableFieldSpec } from '@/src/core/types/editable';
 
-  let reference: HTMLAnchorElement | HTMLButtonElement;
-  let mounted = false;
+  // let buttonReference: HTMLAnchorElement | HTMLButtonElement;
+  let inputReference: HTMLInputElement;
+  let calendarOpened = false;
 
-  const toggleMount = () => {
-    mounted = !mounted;
+  const toggleCalendarPopup = () => {
+    // TODO: On open set handlers for esc key press and outside click
+    calendarOpened = !calendarOpened;
   };
 
   const createdDateStrZ = '2023-12-22T01:23:45.67Z';
 
-  let value = new Date(createdDateStrZ);
-  const dateFormat = 'YYYY-MM-DD HH:mm:ss'; // TODO: To use iso format (above)
-  const dayjsDate = dayjs(value);
-  const fmtDate = dayjsDate.format(dateFormat);
-  // eslint-disable-next-line no-console
-  console.log('[DemoDates] Test', {
-    dayjsDate,
-    fmtDate,
-  });
+  let textValue = createdDateStrZ;
+  let value = new Date(textValue);
+
+  /*
+   * const dateFormat = 'YYYY-MM-DD HH:mm:ss'; // TODO: To use iso format (above)
+   * const dayjsDate = dayjs(value);
+   * const fmtDate = dayjsDate.format(dateFormat);
+   * // eslint-disable-next-line no-console
+   * console.log('[DemoDates] Test', {
+   *   dayjsDate,
+   *   fmtDate,
+   * });
+   */
 
   function selectDate(ev: CustomEvent<Date>) {
     const date = ev.detail;
+    value = date;
+    textValue = date.toISOString();
     console.log('selectDate', {
+      value,
+      textValue,
       date,
       ev,
     });
-    value = date;
+  }
+
+  function handleTextDate(ev: CustomEvent<string>) {
+    const input = ev.currentTarget as HTMLInputElement;
+    const text = input?.value;
+    // const text = ev.detail;
+    textValue = text;
+    const newDate = new Date(text);
+    if (isValidDate(newDate)) {
+      value = newDate;
+    }
+    console.log('selectDate', {
+      value,
+      textValue,
+      text,
+      ev,
+    });
+    debugger;
   }
 </script>
 
@@ -60,11 +89,20 @@
     -->
 
     <h2>Button & Popper:</h2>
-    <Button bind:element={reference} on:click={toggleMount}>{value.toISOString()}</Button>
+    <!--
+    <Button bind:element={buttonReference} on:click={toggleCalendarPopup}>{value.toISOString()}</Button>
+    -->
+    <TextInput bind:element={inputReference} value={value.toISOString()} on:change={handleTextDate}>
+      <svelte:fragment slot="rightSection">
+        <ActionIcon on:click={toggleCalendarPopup} title="Toggle date selector">
+          <Calendar />
+        </ActionIcon>
+      </svelte:fragment>
+    </TextInput>
     <Popper
       title="Select date"
-      {mounted}
-      {reference}
+      mounted={calendarOpened}
+      reference={inputReference}
       position="bottom"
       placement="start"
       gutter={4}

--- a/src/pages/DemoPage/DemoDates/DemoDates.svelte
+++ b/src/pages/DemoPage/DemoDates/DemoDates.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
-  import { DateInput } from 'date-picker-svelte';
+  import { DateInput, DatePicker } from 'date-picker-svelte';
   import { Month } from '@svelteuidev/dates';
   import { Box, Button, Center, Popper } from '@svelteuidev/core';
   import dayjs from 'dayjs';
+
+  // @see:
+  // - https://www.svelteui.org/dates/month
+  // - https://www.svelteui.org/dates/getting-started
+  // - https://www.npmjs.com/package/date-picker-svelte
 
   import { EditableField } from '@/src/components/data';
   // import { TEditableFieldSpec } from '@/src/core/types/editable';
@@ -25,32 +30,53 @@
     dayjsDate,
     fmtDate,
   });
+
+  function selectDate(ev: CustomEvent<Date>) {
+    const date = ev.detail;
+    console.log('selectDate', {
+      date,
+      ev,
+    });
+    value = date;
+  }
 </script>
 
 <div class="DemoDates">
   <h2>DemoDates</h2>
   <div>
-    <EditableField spec={{ id: 'testString', type: 'string' }} />
     <!--
-    -->
+    <EditableField spec={{ id: 'testString', type: 'string' }} />
+
+    <h2>DateInput:</h2>
     <DateInput bind:value />
+    -->
 
+    <h2>DatePicker:</h2>
+    <DatePicker {value} timePrecision="second" on:select={selectDate} />
+
+    <!--
+    <h2>Month:</h2>
     <Month bind:value month={value} onChange={(val) => (value = val)} />
+    -->
 
+    <h2>Button & Popper:</h2>
     <Button bind:element={reference} on:click={toggleMount}>{value.toISOString()}</Button>
     <Popper
+      title="Select date"
       {mounted}
       {reference}
-      withArrow={true}
       position="bottom"
       placement="start"
-      gutter={10}
-      override={{ '& .arrow': { backgroundColor: '$gray100' } }}
+      gutter={4}
     >
-      <Box css={{ backgroundColor: '$gray100', borderRadius: 5, padding: '30px' }}>
-        <Center>Popper content</Center>
-      </Box>
+      <DatePicker {value} timePrecision="second" on:select={selectDate} />
     </Popper>
+
+    <!--
+      TODO: To create `DateInput` input type. Use in `EditableField`.
+    -->
+
+    <EditableField spec={{ id: 'testDate', type: 'date' }} value={value.toISOString()} />
 
     <!--
     // prettier-ignore

--- a/src/pages/DemoPage/DemoDates/DemoDates.svelte
+++ b/src/pages/DemoPage/DemoDates/DemoDates.svelte
@@ -52,29 +52,33 @@
     });
   }
 
-  function handleTextDate(ev: CustomEvent<string>) {
-    const input = ev.currentTarget as HTMLInputElement;
-    const text = input?.value;
-    // const text = ev.detail;
+  function handleChangedDate(text: string) {
     textValue = text;
     const newDate = new Date(text);
     if (isValidDate(newDate)) {
       dateValue = newDate;
     }
-    console.log('selectDate', {
+    console.log('handleChangedDate', {
       dateValue,
       textValue,
       text,
-      ev,
     });
-    debugger;
   }
 
-  // function dateInputChange(ev: unknown) {
-  //   console.log('[DemoDates:dateInputChange]', {
-  //     ev,
-  //   });
-  // }
+  function handleTextDate(ev: CustomEvent<string>) {
+    const input = ev.currentTarget as HTMLInputElement;
+    const text = input?.value;
+    handleChangedDate(text);
+  }
+
+  function dateInputChange(ev: CustomEvent<string>) {
+    const text = ev.detail;
+    console.log('[DemoDates:dateInputChange]', {
+      text,
+      ev,
+    });
+    handleChangedDate(text);
+  }
 </script>
 
 <div class="DemoDates">
@@ -122,9 +126,14 @@
       TODO: To create `DateInput` input type. Use in `EditableField`.
     -->
 
-    <DateInput value={textValue} on:change={handleTextDate} />
+    <DateInput value={textValue} on:change={dateInputChange} />
 
-    <EditableField spec={{ id: 'testDate', type: 'date' }} value={textValue} />
+    <EditableField
+      spec={{ id: 'testDate', type: 'date', label: 'Date', title: 'Date' }}
+      value={textValue}
+    />
+    <!--
+    -->
   </div>
 </div>
 

--- a/src/pages/DemoPage/DemoEditDataSet/DemoEditDataSet.svelte
+++ b/src/pages/DemoPage/DemoEditDataSet/DemoEditDataSet.svelte
@@ -19,6 +19,9 @@
    */
   const dataSetData: TGenericEditableData = [
     {
+      created: undefined,
+    },
+    {
       created: '2023-12-22T01:23:45.67Z',
       source: {
         name: '1,4-Butanediol',
@@ -35,7 +38,7 @@
       comment: 'Identical names',
     },
     {
-      created: '2020-01-01T00:00:00.00Z',
+      created: undefined,
       source: {
         categories: ['X'],
         unit: 'g',
@@ -44,6 +47,8 @@
   ];
   const dataSetSpec = deriveDataSetSpec('sample', dataSetData as TDataSetDictSlot);
   extendDataSetWithFilters(dataSetSpec);
+
+  // console.log('[DemoEditDataSet:dataSetSpec]', dataSetSpec.spec);
 
   /* const sampleDataSetSpec: TGenericEditableSpec = {
    *   id: 'sample',

--- a/src/pages/DemoPage/DemoEditDataSet/DemoEditDataSet.svelte
+++ b/src/pages/DemoPage/DemoEditDataSet/DemoEditDataSet.svelte
@@ -19,6 +19,7 @@
    */
   const dataSetData: TGenericEditableData = [
     {
+      created: '2023-12-22T01:23:45.67Z',
       source: {
         name: '1,4-Butanediol',
         categories: ['Emissions to water', 'river', 'xtra'],
@@ -34,6 +35,7 @@
       comment: 'Identical names',
     },
     {
+      created: '2020-01-01T00:00:00.00Z',
       source: {
         categories: ['X'],
         unit: 'g',

--- a/src/pages/DemoPage/DemoPage.svelte
+++ b/src/pages/DemoPage/DemoPage.svelte
@@ -8,7 +8,7 @@
   import { DemoEditableObjects } from './DemoEditableObjects'; // 2024.01.25, 23:30
   import { DemoDates } from './DemoDates';
   import { DemoEditProperties } from './DemoEditProperties'; // 2024.01.24, 16:45
-  import { DemoEditDataSet } from './DemoEditDataSet'; // 2024.01.28, 20:42
+  import { DemoEditDataSet } from './DemoEditDataSet'; // 2024.01.30, 12:35
   import { DemoTableWithPagination } from './DemoTableWithPagination'; // 2024.01.23
   import { DemoTableWithFilters } from './DemoTableWithFilters'; // 2024.01.24, 15:58
   import { DemoEditorHeader } from './DemoEditorHeader'; // 2024.01.26, 14:01
@@ -31,15 +31,15 @@
       <!--
       <DemoEditableFields />
       <DemoTable />
-      <DemoDates />
       <DemoTableWithPagination />
       <DemoTableWithFilters />
       <DemoEditProperties />
       <DemoEditableObjects />
       <DemoEditorHeader />
       <DemoDataEditorWrapper />
-      -->
       <DemoEditDataSet />
+      -->
+      <DemoDates />
     </div>
   </div>
 </div>

--- a/src/pages/DemoPage/DemoPage.svelte
+++ b/src/pages/DemoPage/DemoPage.svelte
@@ -6,7 +6,7 @@
   import { DemoEditableFields } from './DemoEditableFields';
   import { DemoEditableTable } from './DemoEditableTable';
   import { DemoEditableObjects } from './DemoEditableObjects'; // 2024.01.25, 23:30
-  import { DemoDates } from './DemoDates';
+  import { DemoDates } from './DemoDates'; // 2024.01.31, 19:38
   import { DemoEditProperties } from './DemoEditProperties'; // 2024.01.24, 16:45
   import { DemoEditDataSet } from './DemoEditDataSet'; // 2024.01.30, 12:35
   import { DemoTableWithPagination } from './DemoTableWithPagination'; // 2024.01.23
@@ -37,9 +37,9 @@
       <DemoEditableObjects />
       <DemoEditorHeader />
       <DemoDataEditorWrapper />
-      <DemoEditDataSet />
-      -->
       <DemoDates />
+      -->
+      <DemoEditDataSet />
     </div>
   </div>
 </div>


### PR DESCRIPTION
- 2024.01.13 18.22 Issue #8: Added unfinished demos for date input types (based on '@svelteuidev/dates' and 'date-picker-svelte').
- 2024.01.30 13.19 Issue #8: Add date data field type: created prototype used date-picker-svelte's `DatePicker` and svelteui's `Popper` (in progress).
- 2024.01.31 00.02 Issue #8: Created (in general) a working base for a `DateInput` component (see `DemoDates`).
- 2024.01.31 18.10 Issue #8: Created our own component `DateInput`.
- 2024.01.31 19.36 Issue #8: Finished `DateInput` component. It's used in `EditableField`: it's possible to use 'date' data types now.
- 2024.01.31 20.09 Issue #8: Improved `deriveDataSetSpec` methods to detect date values as single ones and in lists (in columns), added unit dedicated unit tests.
- 2024.01.31 20.31 Issue #8: Updated `DateInput` and `deriveDataSetSpec` methods (with corresponded unit tests) to handle empty dates correctly.

![Edit date field in popup dialog form](https://github.com/lilliputten/svelte-randonneur-app/assets/6855837/6c005fd3-78d0-4e0d-b5e9-579e8767c32c)
